### PR TITLE
Add atomic offer/trade support to API

### DIFF
--- a/apitest/src/test/java/bisq/apitest/ApiTestCase.java
+++ b/apitest/src/test/java/bisq/apitest/ApiTestCase.java
@@ -17,6 +17,8 @@
 
 package bisq.apitest;
 
+import java.time.Duration;
+
 import java.io.File;
 import java.io.IOException;
 
@@ -34,6 +36,7 @@ import static bisq.apitest.config.BisqAppConfig.arbdaemon;
 import static bisq.apitest.config.BisqAppConfig.bobdaemon;
 import static bisq.proto.grpc.DisputeAgentsGrpc.getRegisterDisputeAgentMethod;
 import static bisq.proto.grpc.GetVersionGrpc.getGetVersionMethod;
+import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static java.net.InetAddress.getLoopbackAddress;
 import static java.util.Arrays.stream;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -136,11 +139,7 @@ public class ApiTestCase {
     }
 
     protected static void sleep(long ms) {
-        try {
-            MILLISECONDS.sleep(ms);
-        } catch (InterruptedException ignored) {
-            // empty
-        }
+        sleepUninterruptibly(Duration.ofMillis(ms));
     }
 
     protected final String testName(TestInfo testInfo) {

--- a/apitest/src/test/java/bisq/apitest/method/offer/AbstractOfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/offer/AbstractOfferTest.java
@@ -66,15 +66,29 @@ public abstract class AbstractOfferTest extends MethodTest {
                 bobdaemon);
     }
 
+    public static void createAtomicBsqPaymentAccounts() {
+        alicesBsqAcct = aliceClient.createCryptoCurrencyPaymentAccount("Alice's Atomic Account",
+                BSQ,
+                aliceClient.getUnusedBsqAddress(), // TODO refactor, bsq address not needed for atom acct
+                false,
+                true);
+        bobsBsqAcct = bobClient.createCryptoCurrencyPaymentAccount("Bob's Atomic Account",
+                BSQ,
+                bobClient.getUnusedBsqAddress(),   // TODO refactor, bsq address not needed for atom acct
+                false,
+                true);
+    }
 
     public static void createBsqPaymentAccounts() {
         alicesBsqAcct = aliceClient.createCryptoCurrencyPaymentAccount("Alice's BSQ Account",
                 BSQ,
                 aliceClient.getUnusedBsqAddress(),
+                false,
                 false);
         bobsBsqAcct = bobClient.createCryptoCurrencyPaymentAccount("Bob's BSQ Account",
                 BSQ,
                 bobClient.getUnusedBsqAddress(),
+                false,
                 false);
     }
 

--- a/apitest/src/test/java/bisq/apitest/method/offer/AtomicOfferTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/offer/AtomicOfferTest.java
@@ -1,0 +1,174 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.apitest.method.offer;
+
+import bisq.proto.grpc.AtomicOfferInfo;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static bisq.apitest.config.ApiTestConfig.BSQ;
+import static bisq.apitest.config.ApiTestConfig.BTC;
+import static bisq.cli.TableFormat.formatBalancesTbls;
+import static java.lang.String.format;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static protobuf.OfferPayload.Direction.BUY;
+
+// @Disabled
+@Slf4j
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class AtomicOfferTest extends AbstractOfferTest {
+
+    @BeforeAll
+    public static void setUp() {
+        AbstractOfferTest.setUp();
+        createAtomicBsqPaymentAccounts();
+    }
+
+    @BeforeEach
+    public void generateBtcBlock() {
+        genBtcBlocksThenWait(1, 2000);
+    }
+
+    @Test
+    @Order(1)
+    public void testGetBalancesBeforeCreateOffers() {
+        var alicesBalances = aliceClient.getBalances();
+        log.info("Alice's Before Trade Balance:\n{}", formatBalancesTbls(alicesBalances));
+        var bobsBalances = bobClient.getBalances();
+        log.info("Bob's Before Trade Balance:\n{}", formatBalancesTbls(bobsBalances));
+    }
+
+    @Test
+    @Order(2)
+    public void testAliceCreateAtomicBuyOffer1() {
+        createAtomicOffer();
+    }
+
+    @Test
+    @Order(3)
+    public void testAliceCreateAtomicBuyOffer2() {
+        createAtomicOffer();
+    }
+
+    @Test
+    @Order(4)
+    public void testAliceCreateAtomicBuyOffer3() {
+        createAtomicOffer();
+    }
+
+    @Test
+    @Order(5)
+    public void testAliceCreateAtomicBuyOffer4() {
+        createAtomicOffer();
+    }
+
+    private void createAtomicOffer() {
+        var atomicOffer = aliceClient.createAtomicOffer(BUY.name(),
+                100_000_000L,
+                100_000_000L,
+                "0.00005",
+                alicesBsqAcct.getId());
+        log.info("Atomic Sell BSQ (Buy BTC) OFFER:\n{}", atomicOffer);
+        var newOfferId = atomicOffer.getId();
+        assertNotEquals("", newOfferId);
+        assertEquals(BUY.name(), atomicOffer.getDirection());
+        assertEquals(5_000, atomicOffer.getPrice());
+        assertEquals(100_000_000L, atomicOffer.getAmount());
+        assertEquals(100_000_000L, atomicOffer.getMinAmount());
+        // assertEquals(alicesBsqAcct.getId(), atomicOffer.getMakerPaymentAccountId());
+        assertEquals(BSQ, atomicOffer.getBaseCurrencyCode());
+        assertEquals(BTC, atomicOffer.getCounterCurrencyCode());
+        assertTrue(atomicOffer.getIsCurrencyForMakerFeeBtc());
+
+        testGetMyAtomicOffer(atomicOffer);
+        testGetAtomicOffer(atomicOffer);
+    }
+
+    private void testGetMyAtomicOffer(AtomicOfferInfo atomicOffer) {
+        int numFetchAttempts = 0;
+        while (true) {
+            try {
+                numFetchAttempts++;
+                var fetchedAtomicOffer = aliceClient.getMyAtomicOffer(atomicOffer.getId());
+                assertEquals(atomicOffer.getId(), fetchedAtomicOffer.getId());
+                log.info("Alice found her (my) new atomic offer on attempt # {}.", numFetchAttempts);
+                break;
+            } catch (Exception ex) {
+                log.warn(ex.getMessage());
+
+                if (numFetchAttempts >= 9)
+                    fail(format("Alice giving up on fetching her (my) atomic offer after %d attempts.", numFetchAttempts), ex);
+
+                sleep(1000);
+            }
+        }
+    }
+
+    private void testGetAtomicOffer(AtomicOfferInfo atomicOffer) {
+        int numFetchAttempts = 0;
+        while (true) {
+            try {
+                numFetchAttempts++;
+                var fetchedAtomicOffer = bobClient.getAtomicOffer(atomicOffer.getId());
+                assertEquals(atomicOffer.getId(), fetchedAtomicOffer.getId());
+                log.info("Bob found new available atomic offer on attempt # {}.", numFetchAttempts);
+                break;
+            } catch (Exception ex) {
+                log.warn(ex.getMessage());
+
+                if (numFetchAttempts > 9)
+                    fail(format("Bob gave up on fetching available atomic offer after %d attempts.", numFetchAttempts), ex);
+
+                sleep(1000);
+            }
+        }
+    }
+
+    @Test
+    @Order(6)
+    public void testGetMyAtomicOffers() {
+        var offers = aliceClient.getMyAtomicBsqOffersSortedByDate();
+        assertEquals(4, offers.size());
+    }
+
+    @Test
+    @Order(7)
+    public void testGetAvailableAtomicOffers() {
+        var offers = bobClient.getAtomicOffersSortedByDate();
+        assertEquals(4, offers.size());
+    }
+
+    @Test
+    @Order(8)
+    public void testGetBalancesAfterCreateOffers() {
+        var alicesBalances = aliceClient.getBalances();
+        log.info("Alice's After Trade Balance:\n{}", formatBalancesTbls(alicesBalances));
+        var bobsBalances = bobClient.getBalances();
+        log.info("Bob's After Trade Balance:\n{}", formatBalancesTbls(bobsBalances));
+    }
+}

--- a/apitest/src/test/java/bisq/apitest/method/trade/AtomicTradeTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/AtomicTradeTest.java
@@ -1,0 +1,165 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.apitest.method.trade;
+
+import bisq.proto.grpc.AtomicOfferInfo;
+import bisq.proto.grpc.AtomicTradeInfo;
+
+import protobuf.AtomicTrade;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static bisq.apitest.config.ApiTestConfig.BSQ;
+import static bisq.apitest.config.ApiTestConfig.BTC;
+import static bisq.cli.TableFormat.formatBalancesTbls;
+import static java.lang.String.format;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static protobuf.OfferPayload.Direction.BUY;
+
+
+
+import bisq.apitest.method.offer.AbstractOfferTest;
+
+// @Disabled
+@Slf4j
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class AtomicTradeTest extends AbstractOfferTest {
+
+    private static final String BISQ_FEE_CURRENCY_CODE = BSQ;
+
+    @BeforeAll
+    public static void setUp() {
+        AbstractOfferTest.setUp();
+        createAtomicBsqPaymentAccounts();
+    }
+
+    @BeforeEach
+    public void generateBtcBlock() {
+        genBtcBlocksThenWait(1, 2000);
+    }
+
+    @Test
+    @Order(1)
+    public void testGetBalancesBeforeTrade() {
+        var alicesBalances = aliceClient.getBalances();
+        log.info("Alice's Before Trade Balance:\n{}", formatBalancesTbls(alicesBalances));
+        var bobsBalances = bobClient.getBalances();
+        log.info("Bob's Before Trade Balance:\n{}", formatBalancesTbls(bobsBalances));
+    }
+
+    @Test
+    @Order(2)
+    public void testAliceCreateAtomicBuyOffer() {
+        var atomicOffer = aliceClient.createAtomicOffer(BUY.name(),
+                100_000_000L,
+                100_000_000L,
+                "0.00005",
+                alicesBsqAcct.getId());
+        log.info("Atomic Sell BSQ (Buy BTC) OFFER:\n{}", atomicOffer);
+        var newOfferId = atomicOffer.getId();
+        assertNotEquals("", newOfferId);
+        assertEquals(BUY.name(), atomicOffer.getDirection());
+        assertEquals(5_000, atomicOffer.getPrice());
+        assertEquals(100_000_000L, atomicOffer.getAmount());
+        assertEquals(100_000_000L, atomicOffer.getMinAmount());
+        // assertEquals(alicesBsqAcct.getId(), atomicOffer.getMakerPaymentAccountId());
+        assertEquals(BSQ, atomicOffer.getBaseCurrencyCode());
+        assertEquals(BTC, atomicOffer.getCounterCurrencyCode());
+        assertTrue(atomicOffer.getIsCurrencyForMakerFeeBtc());
+    }
+
+    @Test
+    @Order(3)
+    public void testBobTakesAtomicOffer() {
+        var atomicOffer = getAvailableAtomicOffer();
+
+        var atomicTrade = bobClient.takeAtomicOffer(atomicOffer.getId(),
+                bobsBsqAcct.getId(),
+                BISQ_FEE_CURRENCY_CODE);
+        log.info("Trade at t1: {}", atomicTrade);
+        assertEquals(AtomicTrade.State.PREPARATION.name(), atomicTrade.getState());
+        genBtcBlocksThenWait(1, 3000);
+
+        atomicTrade = getAtomicTrade(atomicTrade.getTradeId());
+        log.info("Trade at t2: {}", atomicTrade);
+        assertEquals(AtomicTrade.State.TX_CONFIRMED.name(), atomicTrade.getState());
+    }
+
+    @Test
+    @Order(4)
+    public void testGetBalancesAfterTrade() {
+        var alicesBalances = aliceClient.getBalances();
+        log.info("Alice's After Trade Balance:\n{}", formatBalancesTbls(alicesBalances));
+        var bobsBalances = bobClient.getBalances();
+        log.info("Bob's After Trade Balance:\n{}", formatBalancesTbls(bobsBalances));
+    }
+
+    private AtomicOfferInfo getAvailableAtomicOffer() {
+        List<AtomicOfferInfo> atomicOffers = new ArrayList<>();
+        int numFetchAttempts = 0;
+        while (atomicOffers.size() == 0) {
+            atomicOffers.addAll(bobClient.getAtomicOffers(BUY.name(), "BSQ"));
+            numFetchAttempts++;
+            if (atomicOffers.size() == 0) {
+                log.warn("No available atomic offer found after {} fetch attempts.", numFetchAttempts);
+                if (numFetchAttempts > 9) {
+                    fail(format("Bob gave up on fetching available atomic offer after %d attempts.", numFetchAttempts));
+                }
+                sleep(1000);
+            } else {
+                assertEquals(1, atomicOffers.size());
+                log.info("Bob found new available atomic offer on attempt # {}.", numFetchAttempts);
+                break;
+            }
+        }
+        // Test api's getAtomicOffer(id).
+        var atomicOffer = bobClient.getAtomicOffer(atomicOffers.get(0).getId());
+        assertEquals(atomicOffers.get(0).getId(), atomicOffer.getId());
+        return atomicOffer;
+    }
+
+    private AtomicTradeInfo getAtomicTrade(String tradeId) {
+        int numFetchAttempts = 0;
+        while (true) {
+            try {
+                numFetchAttempts++;
+                return bobClient.getAtomicTrade(tradeId);
+            } catch (Exception ex) {
+                log.warn(ex.getMessage());
+                if (numFetchAttempts > 9) {
+                    fail(format("Could not find new atomic trade after %d attempts.", numFetchAttempts));
+                } else {
+                    sleep(1000);
+                }
+            }
+        }
+    }
+}

--- a/apitest/src/test/java/bisq/apitest/method/trade/AtomicTradeTestLoop.java
+++ b/apitest/src/test/java/bisq/apitest/method/trade/AtomicTradeTestLoop.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.apitest.method.trade;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+
+
+import bisq.apitest.method.offer.AbstractOfferTest;
+
+// @Disabled
+@Slf4j
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class AtomicTradeTestLoop extends AbstractOfferTest {
+
+    @BeforeAll
+    public static void setUp() {
+        AbstractOfferTest.setUp();
+        createAtomicBsqPaymentAccounts();
+    }
+
+    @Test
+    @Order(1)
+    public void testGetBalancesBeforeTrade() {
+        AtomicTradeTest test = new AtomicTradeTest();
+        runTradeLoop(test);
+    }
+
+    private void runTradeLoop(AtomicTradeTest test) {
+        // TODO Fix wallet inconsistency bugs after 2nd trades.
+        for (int tradeCount = 1; tradeCount <= 2; tradeCount++) {
+            log.warn("================================ Trade # {} ================================", tradeCount);
+            test.testGetBalancesBeforeTrade();
+
+            test.testAliceCreateAtomicBuyOffer();
+            genBtcBlocksThenWait(1, 8000);
+
+            test.testBobTakesAtomicOffer();
+            genBtcBlocksThenWait(1, 8000);
+
+            test.testGetBalancesAfterTrade();
+        }
+    }
+}

--- a/apitest/src/test/java/bisq/apitest/method/wallet/BtcTxFeeRateTest.java
+++ b/apitest/src/test/java/bisq/apitest/method/wallet/BtcTxFeeRateTest.java
@@ -56,8 +56,7 @@ public class BtcTxFeeRateTest extends MethodTest {
     @Order(2)
     public void testSetInvalidTxFeeRateShouldThrowException(final TestInfo testInfo) {
         var currentTxFeeRateInfo = TxFeeRateInfo.fromProto(aliceClient.getTxFeeRate());
-        Throwable exception = assertThrows(StatusRuntimeException.class, () ->
-                aliceClient.setTxFeeRate(10));
+        Throwable exception = assertThrows(StatusRuntimeException.class, () -> aliceClient.setTxFeeRate(1));
         String expectedExceptionMessage =
                 format("UNKNOWN: tx fee rate preference must be >= %d sats/byte",
                         currentTxFeeRateInfo.getMinFeeServiceRate());

--- a/cli/src/main/java/bisq/cli/CliMain.java
+++ b/cli/src/main/java/bisq/cli/CliMain.java
@@ -546,10 +546,12 @@ public class CliMain {
                     var currencyCode = opts.getCurrencyCode();
                     var address = opts.getAddress();
                     var isTradeInstant = opts.getIsTradeInstant();
+                    var isTradeAtomic = opts.getIsTradeAtomic();
                     var paymentAccount = client.createCryptoCurrencyPaymentAccount(accountName,
                             currencyCode,
                             address,
-                            isTradeInstant);
+                            isTradeInstant,
+                            isTradeAtomic);
                     out.println("payment account saved");
                     out.println(formatPaymentAcctTbl(singletonList(paymentAccount)));
                     return;

--- a/cli/src/main/java/bisq/cli/opts/AbstractMethodOptionParser.java
+++ b/cli/src/main/java/bisq/cli/opts/AbstractMethodOptionParser.java
@@ -29,6 +29,7 @@ import lombok.Getter;
 
 import static bisq.cli.opts.OptLabel.OPT_HELP;
 
+@SuppressWarnings("unchecked")
 abstract class AbstractMethodOptionParser implements MethodOpts {
 
     // The full command line args passed to CliMain.main(String[] args).
@@ -52,7 +53,6 @@ abstract class AbstractMethodOptionParser implements MethodOpts {
     public AbstractMethodOptionParser parse() {
         try {
             options = parser.parse(new ArgumentList(args).getMethodArguments());
-            //noinspection unchecked
             nonOptionArguments = (List<String>) options.nonOptionArguments();
             return this;
         } catch (OptionException ex) {

--- a/cli/src/main/java/bisq/cli/opts/CreateCryptoCurrencyPaymentAcctOptionParser.java
+++ b/cli/src/main/java/bisq/cli/opts/CreateCryptoCurrencyPaymentAcctOptionParser.java
@@ -20,10 +20,7 @@ package bisq.cli.opts;
 
 import joptsimple.OptionSpec;
 
-import static bisq.cli.opts.OptLabel.OPT_ACCOUNT_NAME;
-import static bisq.cli.opts.OptLabel.OPT_ADDRESS;
-import static bisq.cli.opts.OptLabel.OPT_CURRENCY_CODE;
-import static bisq.cli.opts.OptLabel.OPT_TRADE_INSTANT;
+import static bisq.cli.opts.OptLabel.*;
 
 public class CreateCryptoCurrencyPaymentAcctOptionParser extends AbstractMethodOptionParser implements MethodOpts {
 
@@ -37,6 +34,11 @@ public class CreateCryptoCurrencyPaymentAcctOptionParser extends AbstractMethodO
             .withRequiredArg();
 
     final OptionSpec<Boolean> tradeInstantOpt = parser.accepts(OPT_TRADE_INSTANT, "create trade instant account")
+            .withOptionalArg()
+            .ofType(boolean.class)
+            .defaultsTo(Boolean.FALSE);
+
+    final OptionSpec<Boolean> tradeAtomicOpt = parser.accepts(OPT_TRADE_ATOMIC, "create trade atomic account")
             .withOptionalArg()
             .ofType(boolean.class)
             .defaultsTo(Boolean.FALSE);
@@ -81,5 +83,9 @@ public class CreateCryptoCurrencyPaymentAcctOptionParser extends AbstractMethodO
 
     public boolean getIsTradeInstant() {
         return options.valueOf(tradeInstantOpt);
+    }
+
+    public boolean getIsTradeAtomic() {
+        return options.valueOf(tradeAtomicOpt);
     }
 }

--- a/cli/src/main/java/bisq/cli/opts/OptLabel.java
+++ b/cli/src/main/java/bisq/cli/opts/OptLabel.java
@@ -43,6 +43,7 @@ public class OptLabel {
     public final static String OPT_REGISTRATION_KEY = "registration-key";
     public final static String OPT_SECURITY_DEPOSIT = "security-deposit";
     public final static String OPT_SHOW_CONTRACT = "show-contract";
+    public final static String OPT_TRADE_ATOMIC = "trade-atomic";
     public final static String OPT_TRADE_ID = "trade-id";
     public final static String OPT_TRADE_INSTANT = "trade-instant";
     public final static String OPT_TIMEOUT = "timeout";

--- a/core/src/main/java/bisq/core/api/CoreApi.java
+++ b/core/src/main/java/bisq/core/api/CoreApi.java
@@ -28,6 +28,8 @@ import bisq.core.offer.OpenOffer;
 import bisq.core.payment.PaymentAccount;
 import bisq.core.payment.payload.PaymentMethod;
 import bisq.core.trade.Trade;
+import bisq.core.trade.atomic.AtomicTrade;
+import bisq.core.trade.handlers.TradeResultHandler;
 import bisq.core.trade.statistics.TradeStatistics3;
 import bisq.core.trade.statistics.TradeStatisticsManager;
 
@@ -35,6 +37,8 @@ import bisq.common.app.Version;
 import bisq.common.config.Config;
 import bisq.common.handlers.ErrorMessageHandler;
 import bisq.common.handlers.ResultHandler;
+
+import bisq.proto.grpc.AtomicOfferInfo;
 
 import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.Transaction;
@@ -118,38 +122,72 @@ public class CoreApi {
     // Offers
     ///////////////////////////////////////////////////////////////////////////////////////////
 
+    public Offer getAtomicOffer(String id) {
+        return coreOffersService.getAtomicOffer(id);
+    }
+
     public Offer getOffer(String id) {
         return coreOffersService.getOffer(id);
+    }
+
+    public Offer getMyAtomicOffer(String id) {
+        return coreOffersService.getMyAtomicOffer(id);
     }
 
     public Offer getMyOffer(String id) {
         return coreOffersService.getMyOffer(id);
     }
 
+    public List<Offer> getAtomicOffers(String direction, String currencyCode) {
+        return coreOffersService.getAtomicOffers(direction, currencyCode);
+    }
+
     public List<Offer> getOffers(String direction, String currencyCode) {
         return coreOffersService.getOffers(direction, currencyCode);
+    }
+
+    public List<Offer> getMyAtomicOffers(String direction, String currencyCode) {
+        return coreOffersService.getMyAtomicOffers(direction, currencyCode);
     }
 
     public List<Offer> getMyOffers(String direction, String currencyCode) {
         return coreOffersService.getMyOffers(direction, currencyCode);
     }
 
+    public OpenOffer getMyOpenAtomicOffer(String id) {
+        return coreOffersService.getMyOpenAtomicOffer(id);
+    }
+
     public OpenOffer getMyOpenOffer(String id) {
         return coreOffersService.getMyOpenOffer(id);
     }
 
-    public void createAnPlaceOffer(String currencyCode,
-                                   String directionAsString,
-                                   String priceAsString,
-                                   boolean useMarketBasedPrice,
-                                   double marketPriceMargin,
-                                   long amountAsLong,
-                                   long minAmountAsLong,
-                                   double buyerSecurityDeposit,
-                                   long triggerPrice,
-                                   String paymentAccountId,
-                                   String makerFeeCurrencyCode,
-                                   Consumer<Offer> resultHandler) {
+    public void createAndPlaceAtomicOffer(String directionAsString,
+                                          long amountAsLong,
+                                          long minAmountAsLong,
+                                          String priceAsString,
+                                          String paymentAccountId,
+                                          Consumer<Offer> resultHandler) {
+        coreOffersService.createAndPlaceAtomicOffer(directionAsString,
+                amountAsLong,
+                minAmountAsLong,
+                priceAsString,
+                paymentAccountId,
+                resultHandler);
+    }
+
+    public void createAndPlaceOffer(String currencyCode,
+                                    String directionAsString,
+                                    String priceAsString,
+                                    boolean useMarketBasedPrice,
+                                    double marketPriceMargin,
+                                    long amountAsLong,
+                                    long minAmountAsLong,
+                                    double buyerSecurityDeposit,
+                                    long triggerPrice,
+                                    String paymentAccountId,
+                                    String makerFeeCurrencyCode,
+                                    Consumer<Offer> resultHandler) {
         coreOffersService.createAndPlaceOffer(currencyCode,
                 directionAsString,
                 priceAsString,
@@ -213,11 +251,13 @@ public class CoreApi {
     public PaymentAccount createCryptoCurrencyPaymentAccount(String accountName,
                                                              String currencyCode,
                                                              String address,
-                                                             boolean tradeInstant) {
+                                                             boolean tradeInstant,
+                                                             boolean tradeAtomic) {
         return paymentAccountsService.createCryptoCurrencyPaymentAccount(accountName,
                 currencyCode,
                 address,
-                tradeInstant);
+                tradeInstant,
+                tradeAtomic);
     }
 
     public List<PaymentMethod> getCryptoCurrencyPaymentMethods() {
@@ -235,6 +275,19 @@ public class CoreApi {
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Trades
     ///////////////////////////////////////////////////////////////////////////////////////////
+
+    public void takeAtomicOffer(String offerId,
+                                String paymentAccountId,
+                                String takerFeeCurrencyCode,
+                                TradeResultHandler<AtomicTrade> tradeResultHandler,
+                                ErrorMessageHandler errorMessageHandler) {
+        Offer atomicOffer = coreOffersService.getAtomicOffer(offerId);
+        coreTradesService.takeAtomicOffer(atomicOffer,
+                paymentAccountId,
+                takerFeeCurrencyCode,
+                tradeResultHandler,
+                errorMessageHandler);
+    }
 
     public void takeOffer(String offerId,
                           String paymentAccountId,
@@ -263,6 +316,10 @@ public class CoreApi {
 
     public void withdrawFunds(String tradeId, String address, String memo) {
         coreTradesService.withdrawFunds(tradeId, address, memo);
+    }
+
+    public AtomicTrade getAtomicTrade(String tradeId) {
+        return coreTradesService.getAtomicTrade(tradeId);
     }
 
     public Trade getTrade(String tradeId) {

--- a/core/src/main/java/bisq/core/api/CorePaymentAccountsService.java
+++ b/core/src/main/java/bisq/core/api/CorePaymentAccountsService.java
@@ -20,6 +20,7 @@ package bisq.core.api;
 import bisq.core.account.witness.AccountAgeWitnessService;
 import bisq.core.api.model.PaymentAccountForm;
 import bisq.core.locale.CryptoCurrency;
+import bisq.core.payment.AssetAccount;
 import bisq.core.payment.CryptoCurrencyAccount;
 import bisq.core.payment.InstantCryptoCurrencyAccount;
 import bisq.core.payment.PaymentAccount;
@@ -102,7 +103,8 @@ class CorePaymentAccountsService {
     PaymentAccount createCryptoCurrencyPaymentAccount(String accountName,
                                                       String currencyCode,
                                                       String address,
-                                                      boolean tradeInstant) {
+                                                      boolean tradeInstant,
+                                                      boolean tradeAtomic) {
         String bsqCode = currencyCode.toUpperCase();
         if (!bsqCode.equals("BSQ"))
             throw new IllegalArgumentException("api does not currently support " + currencyCode + " accounts");
@@ -110,12 +112,21 @@ class CorePaymentAccountsService {
         // Validate the BSQ address string but ignore the return value.
         coreWalletsService.getValidBsqLegacyAddress(address);
 
-        var cryptoCurrencyAccount = tradeInstant
-                ? (InstantCryptoCurrencyAccount) PaymentAccountFactory.getPaymentAccount(PaymentMethod.BLOCK_CHAINS_INSTANT)
-                : (CryptoCurrencyAccount) PaymentAccountFactory.getPaymentAccount(PaymentMethod.BLOCK_CHAINS);
+        // TODO Split into 2 methods: createAtomicPaymentAccount(), createCryptoCurrencyPaymentAccount().
+        PaymentAccount cryptoCurrencyAccount;
+        if (tradeAtomic) {
+            cryptoCurrencyAccount = PaymentAccountFactory.getPaymentAccount(PaymentMethod.ATOMIC);
+        } else {
+            cryptoCurrencyAccount = tradeInstant
+                    ? (InstantCryptoCurrencyAccount) PaymentAccountFactory.getPaymentAccount(PaymentMethod.BLOCK_CHAINS_INSTANT)
+                    : (CryptoCurrencyAccount) PaymentAccountFactory.getPaymentAccount(PaymentMethod.BLOCK_CHAINS);
+        }
         cryptoCurrencyAccount.init();
         cryptoCurrencyAccount.setAccountName(accountName);
-        cryptoCurrencyAccount.setAddress(address);
+        if (!tradeAtomic) {
+            ((AssetAccount) cryptoCurrencyAccount).setAddress(address);
+        }
+
         Optional<CryptoCurrency> cryptoCurrency = getCryptoCurrency(bsqCode);
         cryptoCurrency.ifPresent(cryptoCurrencyAccount::setSingleTradeCurrency);
         user.addPaymentAccount(cryptoCurrencyAccount);

--- a/core/src/main/java/bisq/core/api/CoreWalletsService.java
+++ b/core/src/main/java/bisq/core/api/CoreWalletsService.java
@@ -84,7 +84,6 @@ import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nullable;
 
-import static bisq.common.config.BaseCurrencyNetwork.BTC_DAO_REGTEST;
 import static bisq.core.btc.wallet.Restrictions.getMinNonDustOutput;
 import static bisq.core.util.ParsingUtils.parseToCoin;
 import static java.lang.String.format;

--- a/core/src/main/java/bisq/core/api/model/AtomicOfferInfo.java
+++ b/core/src/main/java/bisq/core/api/model/AtomicOfferInfo.java
@@ -1,0 +1,244 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.api.model;
+
+import bisq.core.offer.Offer;
+
+import bisq.common.Payload;
+
+import java.util.Objects;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@EqualsAndHashCode
+@ToString
+@Getter
+public class AtomicOfferInfo implements Payload {
+    private final String id;
+    private final String direction;
+    private final long amount;
+    private final long minAmount;
+    private final long price;
+    private final String makerPaymentAccountId;
+    private final String paymentMethodId;
+    private final String paymentMethodShortName;
+    private final String baseCurrencyCode;
+    private final String counterCurrencyCode;
+    private final long date;
+    private final String ownerNodeAddress;
+    private final String pubKeyRing; // TODO ?
+    private final String versionNumber;
+    private final int protocolVersion;
+    private final boolean isCurrencyForMakerFeeBtc;
+
+    public AtomicOfferInfo(AtomicOfferInfoBuilder builder) {
+        this.id = builder.id;
+        this.direction = builder.direction;
+        this.amount = builder.amount;
+        this.minAmount = builder.minAmount;
+        this.price = builder.price;
+        this.makerPaymentAccountId = builder.makerPaymentAccountId;
+        this.paymentMethodId = builder.paymentMethodId;
+        this.paymentMethodShortName = builder.paymentMethodShortName;
+        this.baseCurrencyCode = builder.baseCurrencyCode;
+        this.counterCurrencyCode = builder.counterCurrencyCode;
+        this.date = builder.date;
+        this.ownerNodeAddress = builder.ownerNodeAddress;
+        this.pubKeyRing = builder.pubKeyRing;
+        this.versionNumber = builder.versionNumber;
+        this.protocolVersion = builder.protocolVersion;
+        this.isCurrencyForMakerFeeBtc = builder.isCurrencyForMakerFeeBtc;
+    }
+
+    public static AtomicOfferInfo toAtomicOfferInfo(Offer offer) {
+        // TODO support triggerPrice
+        return getAtomicOfferInfoBuilder(offer).build();
+    }
+
+    private static AtomicOfferInfoBuilder getAtomicOfferInfoBuilder(Offer offer) {
+        return new AtomicOfferInfoBuilder()
+                .withId(offer.getId())
+                .withDirection(offer.getDirection().name())
+                .withAmount(offer.getAmount().value)
+                .withMinAmount(offer.getMinAmount().value)
+                .withPrice(Objects.requireNonNull(offer.getPrice()).getValue())
+                //.withMakerPaymentAccountId(offer.getOfferPayloadI().getMakerPaymentAccountId())
+                //.withPaymentMethodId(offer.getOfferPayloadI().getPaymentMethodId())
+                //.withPaymentMethodShortName(getPaymentMethodById(offer.getOfferPayloadI().getPaymentMethodId()).getShortName())
+                .withBaseCurrencyCode(offer.getOfferPayloadI().getBaseCurrencyCode())
+                .withCounterCurrencyCode(offer.getOfferPayloadI().getCounterCurrencyCode())
+                .withDate(offer.getDate().getTime())
+                .withOwnerNodeAddress(offer.getOfferPayloadI().getOwnerNodeAddress().getFullAddress())
+                .withPubKeyRing(offer.getOfferPayloadI().getPubKeyRing().toString())
+                .withVersionNumber(offer.getOfferPayloadI().getVersionNr())
+                .withProtocolVersion(offer.getOfferPayloadI().getProtocolVersion())
+                .withIsCurrencyForMakerFeeBtc(offer.isCurrencyForMakerFeeBtc());
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // PROTO BUFFER
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public bisq.proto.grpc.AtomicOfferInfo toProtoMessage() {
+        return bisq.proto.grpc.AtomicOfferInfo.newBuilder()
+                .setId(id)
+                .setDirection(direction)
+                .setAmount(amount)
+                .setMinAmount(minAmount)
+                .setPrice(price)
+                //.setMakerPaymentAccountId(makerPaymentAccountId)
+                //.setPaymentMethodId(paymentMethodId)
+                //.setPaymentMethodShortName(paymentMethodShortName)
+                .setBaseCurrencyCode(baseCurrencyCode)
+                .setCounterCurrencyCode(counterCurrencyCode)
+                .setDate(date)
+                .setOwnerNodeAddress(ownerNodeAddress)
+                .setPubKeyRing(pubKeyRing)
+                .setVersionNr(versionNumber)
+                .setProtocolVersion(protocolVersion)
+                .setIsCurrencyForMakerFeeBtc(isCurrencyForMakerFeeBtc)
+                .build();
+    }
+
+    public static AtomicOfferInfo fromProto(bisq.proto.grpc.AtomicOfferInfo proto) {
+        return new AtomicOfferInfoBuilder()
+                .withId(proto.getId())
+                .withDirection(proto.getDirection())
+                .withAmount(proto.getAmount())
+                .withMinAmount(proto.getMinAmount())
+                .withPrice(proto.getPrice())
+                //.withMakerPaymentAccountId(proto.getMakerPaymentAccountId())
+                //.withPaymentMethodId(proto.getPaymentMethodId())
+                //.withPaymentMethodShortName(proto.getPaymentMethodShortName())
+                .withBaseCurrencyCode(proto.getBaseCurrencyCode())
+                .withCounterCurrencyCode(proto.getCounterCurrencyCode())
+                .withDate(proto.getDate())
+                .withOwnerNodeAddress(proto.getOwnerNodeAddress())
+                .withPubKeyRing(proto.getPubKeyRing())
+                .withVersionNumber(proto.getVersionNr())
+                .withProtocolVersion(proto.getProtocolVersion())
+                .withIsCurrencyForMakerFeeBtc(proto.getIsCurrencyForMakerFeeBtc())
+                .build();
+    }
+
+    public static class AtomicOfferInfoBuilder {
+        private String id;
+        private String direction;
+        private long amount;
+        private long minAmount;
+        private long price;
+        private String makerPaymentAccountId;
+        private String paymentMethodId;
+        private String paymentMethodShortName;
+        private String baseCurrencyCode;
+        private String counterCurrencyCode;
+        private long date;
+        private String ownerNodeAddress;
+        private String pubKeyRing;
+        private String versionNumber;
+        private int protocolVersion;
+        private boolean isCurrencyForMakerFeeBtc;
+
+        public AtomicOfferInfoBuilder withId(String id) {
+            this.id = id;
+            return this;
+        }
+
+        public AtomicOfferInfoBuilder withDirection(String direction) {
+            this.direction = direction;
+            return this;
+        }
+
+        public AtomicOfferInfoBuilder withAmount(long amount) {
+            this.amount = amount;
+            return this;
+        }
+
+        public AtomicOfferInfoBuilder withMinAmount(long minAmount) {
+            this.minAmount = minAmount;
+            return this;
+        }
+
+        public AtomicOfferInfoBuilder withPrice(long price) {
+            this.price = price;
+            return this;
+        }
+
+        public AtomicOfferInfoBuilder withMakerPaymentAccountId(String makerPaymentAccountId) {
+            this.makerPaymentAccountId = makerPaymentAccountId;
+            return this;
+        }
+
+        public AtomicOfferInfoBuilder withPaymentMethodId(String paymentMethodId) {
+            this.paymentMethodId = paymentMethodId;
+            return this;
+        }
+
+        public AtomicOfferInfoBuilder withPaymentMethodShortName(String paymentMethodShortName) {
+            this.paymentMethodShortName = paymentMethodShortName;
+            return this;
+        }
+
+        public AtomicOfferInfoBuilder withBaseCurrencyCode(String baseCurrencyCode) {
+            this.baseCurrencyCode = baseCurrencyCode;
+            return this;
+        }
+
+        public AtomicOfferInfoBuilder withCounterCurrencyCode(String counterCurrencyCode) {
+            this.counterCurrencyCode = counterCurrencyCode;
+            return this;
+        }
+
+        public AtomicOfferInfoBuilder withDate(long date) {
+            this.date = date;
+            return this;
+        }
+
+        public AtomicOfferInfoBuilder withOwnerNodeAddress(String ownerNodeAddress) {
+            this.ownerNodeAddress = ownerNodeAddress;
+            return this;
+        }
+
+        public AtomicOfferInfoBuilder withPubKeyRing(String pubKeyRing) {
+            this.pubKeyRing = pubKeyRing;
+            return this;
+        }
+
+        public AtomicOfferInfoBuilder withVersionNumber(String versionNumber) {
+            this.versionNumber = versionNumber;
+            return this;
+        }
+
+        public AtomicOfferInfoBuilder withProtocolVersion(int protocolVersion) {
+            this.protocolVersion = protocolVersion;
+            return this;
+        }
+
+        public AtomicOfferInfoBuilder withIsCurrencyForMakerFeeBtc(boolean isCurrencyForMakerFeeBtc) {
+            this.isCurrencyForMakerFeeBtc = isCurrencyForMakerFeeBtc;
+            return this;
+        }
+
+        public AtomicOfferInfo build() {
+            return new AtomicOfferInfo(this);
+        }
+    }
+}

--- a/core/src/main/java/bisq/core/api/model/AtomicTradeInfo.java
+++ b/core/src/main/java/bisq/core/api/model/AtomicTradeInfo.java
@@ -1,0 +1,366 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.api.model;
+
+import bisq.core.trade.atomic.AtomicTrade;
+
+import bisq.common.Payload;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+import static bisq.core.api.model.AtomicOfferInfo.toAtomicOfferInfo;
+
+@EqualsAndHashCode
+@ToString
+@Getter
+public class AtomicTradeInfo implements Payload {
+
+    private final AtomicOfferInfo atomicOffer;
+    private final String tradeId;
+    private final String tempTradingPeerNodeAddress;
+    private final String peerNodeAddress;
+    private final String txId;
+    private final long bsqTradeAmount;
+    private final long bsqMaxTradeAmount;
+    private final long bsqMinTradeAmount;
+    private final long btcTradeAmount;
+    private final long btcMaxTradeAmount;
+    private final long btcMinTradeAmount;
+    private final long tradePrice;
+    private final boolean isCurrencyForMakerFeeBtc;
+    private final boolean isCurrencyForTakerFeeBtc;
+    private final long bsqMakerTradeFee;
+    private final long btcMakerTradeFee;
+    private final long bsqTakerTradeFee;
+    private final long btcTakerTradeFee;
+    private final long txFeePerVbyte;
+    private final long txFee;
+    private final String makerBsqAddress;
+    private final String makerBtcAddress;
+    private final String takerBsqAddress;
+    private final String takerBtcAddress;
+    private final long takeOfferDate;
+    private final String state;
+    private final String errorMessage;
+
+    public AtomicTradeInfo(AtomicTradeInfoBuilder builder) {
+        this.atomicOffer = builder.atomicOffer;
+        this.tradeId = builder.tradeId;
+        this.tempTradingPeerNodeAddress = builder.tempTradingPeerNodeAddress;
+        this.peerNodeAddress = builder.peerNodeAddress;
+        this.txId = builder.txId;
+        this.bsqTradeAmount = builder.bsqTradeAmount;
+        this.bsqMaxTradeAmount = builder.bsqMaxTradeAmount;
+        this.bsqMinTradeAmount = builder.bsqMinTradeAmount;
+        this.btcTradeAmount = builder.btcTradeAmount;
+        this.btcMaxTradeAmount = builder.btcMaxTradeAmount;
+        this.btcMinTradeAmount = builder.btcMinTradeAmount;
+        this.tradePrice = builder.tradePrice;
+        this.isCurrencyForMakerFeeBtc = builder.isCurrencyForMakerFeeBtc;
+        this.isCurrencyForTakerFeeBtc = builder.isCurrencyForTakerFeeBtc;
+        this.bsqMakerTradeFee = builder.bsqMakerTradeFee;
+        this.btcMakerTradeFee = builder.btcMakerTradeFee;
+        this.bsqTakerTradeFee = builder.bsqTakerTradeFee;
+        this.btcTakerTradeFee = builder.btcTakerTradeFee;
+        this.txFeePerVbyte = builder.txFeePerVbyte;
+        this.txFee = builder.txFee;
+        this.makerBsqAddress = builder.makerBsqAddress;
+        this.makerBtcAddress = builder.makerBtcAddress;
+        this.takerBsqAddress = builder.takerBsqAddress;
+        this.takerBtcAddress = builder.takerBtcAddress;
+        this.takeOfferDate = builder.takeOfferDate;
+        this.state = builder.state;
+        this.errorMessage = builder.errorMessage;
+    }
+
+    public static AtomicTradeInfo toAtomicTradeInfo(AtomicTrade trade) {
+        return toAtomicTradeInfo(trade, null);
+    }
+
+    public static AtomicTradeInfo toAtomicTradeInfo(AtomicTrade trade, String role) {
+        return new AtomicTradeInfoBuilder()
+                .withAtomicOffer(toAtomicOfferInfo(trade.getOffer()))
+                .withTradeId(trade.getId())
+                .withTempTradingPeerNodeAddress(trade.getAtomicProcessModel().getTempTradingPeerNodeAddress().getFullAddress())
+                .withPeerNodeAddress(trade.getPeerNodeAddress().getFullAddress())
+                .withTxId(trade.getTxId())
+                .withBsqTradeAmount(trade.getAtomicProcessModel().getBsqTradeAmount())
+                .withBsqMaxTradeAmount(trade.getAtomicProcessModel().getBsqMaxTradeAmount())
+                .withBsqMinTradeAmount(trade.getAtomicProcessModel().getBsqMinTradeAmount())
+                .withBtcTradeAmount(trade.getAtomicProcessModel().getBtcTradeAmount())
+                .withBtcMaxTradeAmount(trade.getAtomicProcessModel().getBtcMaxTradeAmount())
+                .withBtcMinTradeAmount(trade.getAtomicProcessModel().getBtcMinTradeAmount())
+                .withTradePrice(trade.getAtomicProcessModel().getTradePrice())
+                .withIsCurrencyForMakerFeeBtc(trade.isCurrencyForMakerFeeBtc())
+                .withIsCurrencyForTakerFeeBtc(trade.isCurrencyForTakerFeeBtc())
+                .withBsqMakerTradeFee(trade.getAtomicProcessModel().getBsqMakerTradeFee())
+                .withBtcMakerTradeFee(trade.getAtomicProcessModel().getBtcMakerTradeFee())
+                .withBsqTakerTradeFee(trade.getAtomicProcessModel().getBsqTakerTradeFee())
+                .withBtcTakerTradeFee(trade.getAtomicProcessModel().getBtcTakerTradeFee())
+                .withTxFeePerVbyte(trade.getAtomicProcessModel().getTxFeePerVbyte())
+                .withTxFee(trade.getAtomicProcessModel().getTxFee())
+                .withMakerBsqAddress(trade.getAtomicProcessModel().getMakerBsqAddress())
+                .withMakerBtcAddress(trade.getAtomicProcessModel().getMakerBtcAddress())
+                .withTakerBsqAddress(trade.getAtomicProcessModel().getTakerBsqAddress())
+                .withTakerBtcAddress(trade.getAtomicProcessModel().getTakerBtcAddress())
+                .withTakeOfferDate(trade.getTakeOfferDate())
+                .withState(trade.getState().name())
+                .withErrorMessage(trade.getErrorMessage())
+                .build();
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    // PROTO BUFFER
+    ///////////////////////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public bisq.proto.grpc.AtomicTradeInfo toProtoMessage() {
+        return bisq.proto.grpc.AtomicTradeInfo.newBuilder()
+                .setAtomicOffer(atomicOffer.toProtoMessage())
+                .setTradeId(tradeId)
+                .setTempTradingPeerNodeAddress(tempTradingPeerNodeAddress != null ? tempTradingPeerNodeAddress : "")
+                .setPeerNodeAddress(peerNodeAddress != null ? peerNodeAddress : "")
+                .setTxId(txId != null ? txId : "")
+                .setBsqTradeAmount(bsqTradeAmount)
+                .setBsqMaxTradeAmount(bsqMaxTradeAmount)
+                .setBsqMinTradeAmount(bsqMinTradeAmount)
+                .setBtcTradeAmount(btcTradeAmount)
+                .setBtcMaxTradeAmount(btcMaxTradeAmount)
+                .setBtcMinTradeAmount(btcMinTradeAmount)
+                .setTradePrice(tradePrice)
+                .setIsCurrencyForMakerFeeBtc(isCurrencyForMakerFeeBtc)
+                .setIsCurrencyForTakerFeeBtc(isCurrencyForTakerFeeBtc)
+                .setBsqMakerTradeFee(bsqMakerTradeFee)
+                .setBtcMakerTradeFee(btcMakerTradeFee)
+                .setBsqTakerTradeFee(bsqTakerTradeFee)
+                .setBtcTakerTradeFee(btcTakerTradeFee)
+                .setTxFeePerVbyte(txFeePerVbyte)
+                .setTxFee(txFee)
+                .setMakerBsqAddress(makerBsqAddress != null ? makerBsqAddress : "")
+                .setTakerBsqAddress(takerBsqAddress != null ? takerBsqAddress : "")
+                .setMakerBtcAddress(makerBtcAddress != null ? makerBtcAddress : "")
+                .setTakerBtcAddress(takerBtcAddress != null ? takerBtcAddress : "")
+                .setTakeOfferDate(takeOfferDate)
+                .setState(state)
+                .setErrorMessage(errorMessage != null ? errorMessage : "")
+                .build();
+    }
+
+    public static AtomicTradeInfo fromProto(bisq.proto.grpc.AtomicTradeInfo proto) {
+        return new AtomicTradeInfoBuilder()
+                .withAtomicOffer(AtomicOfferInfo.fromProto(proto.getAtomicOffer()))
+                .withTradeId(proto.getTradeId())
+                .withTempTradingPeerNodeAddress(proto.getTempTradingPeerNodeAddress())
+                .withPeerNodeAddress(proto.getPeerNodeAddress())
+                .withTxId(proto.getTxId())
+                .withBsqTradeAmount(proto.getBsqTradeAmount())
+                .withBsqMaxTradeAmount(proto.getBsqMaxTradeAmount())
+                .withBsqMinTradeAmount(proto.getBsqMinTradeAmount())
+                .withBtcTradeAmount(proto.getBtcTradeAmount())
+                .withBtcMaxTradeAmount(proto.getBtcMaxTradeAmount())
+                .withBtcMinTradeAmount(proto.getBtcMinTradeAmount())
+                .withTradePrice(proto.getTradePrice())
+                .withIsCurrencyForMakerFeeBtc(proto.getIsCurrencyForMakerFeeBtc())
+                .withIsCurrencyForTakerFeeBtc(proto.getIsCurrencyForTakerFeeBtc())
+                .withBsqMakerTradeFee(proto.getBsqMakerTradeFee())
+                .withBtcMakerTradeFee(proto.getBtcMakerTradeFee())
+                .withBsqTakerTradeFee(proto.getBsqTakerTradeFee())
+                .withBtcTakerTradeFee(proto.getBtcTakerTradeFee())
+                .withTxFeePerVbyte(proto.getTxFeePerVbyte())
+                .withTxFee(proto.getTxFee())
+                .withMakerBsqAddress(proto.getMakerBsqAddress())
+                .withMakerBtcAddress(proto.getMakerBtcAddress())
+                .withTakerBsqAddress(proto.getTakerBsqAddress())
+                .withTakerBtcAddress(proto.getTakerBtcAddress())
+                .withTakeOfferDate(proto.getTakeOfferDate())
+                .withState(proto.getState())
+                .withErrorMessage(proto.getErrorMessage())
+                .build();
+    }
+
+    public static class AtomicTradeInfoBuilder {
+        private AtomicOfferInfo atomicOffer;
+        private String tradeId;
+        private String tempTradingPeerNodeAddress;
+        private String peerNodeAddress;
+        private String txId;
+        private long bsqTradeAmount;
+        private long bsqMaxTradeAmount;
+        private long bsqMinTradeAmount;
+        private long btcTradeAmount;
+        private long btcMaxTradeAmount;
+        private long btcMinTradeAmount;
+        private long tradePrice;
+        private boolean isCurrencyForMakerFeeBtc;
+        private boolean isCurrencyForTakerFeeBtc;
+        private long bsqMakerTradeFee;
+        private long btcMakerTradeFee;
+        private long bsqTakerTradeFee;
+        private long btcTakerTradeFee;
+        private long txFeePerVbyte;
+        private long txFee;
+        private String makerBsqAddress;
+        private String makerBtcAddress;
+        private String takerBsqAddress;
+        private String takerBtcAddress;
+        private long takeOfferDate;
+        private String state;
+        private String errorMessage;
+
+        public AtomicTradeInfoBuilder withAtomicOffer(AtomicOfferInfo atomicOffer) {
+            this.atomicOffer = atomicOffer;
+            return this;
+        }
+
+        public AtomicTradeInfoBuilder withTradeId(String tradeId) {
+            this.tradeId = tradeId;
+            return this;
+        }
+
+        public AtomicTradeInfoBuilder withTempTradingPeerNodeAddress(String tempTradingPeerNodeAddress) {
+            this.tempTradingPeerNodeAddress = tempTradingPeerNodeAddress;
+            return this;
+        }
+
+        public AtomicTradeInfoBuilder withPeerNodeAddress(String peerNodeAddress) {
+            this.peerNodeAddress = peerNodeAddress;
+            return this;
+        }
+
+        public AtomicTradeInfoBuilder withTxId(String txId) {
+            this.txId = txId;
+            return this;
+        }
+
+        public AtomicTradeInfoBuilder withBsqTradeAmount(long bsqTradeAmount) {
+            this.bsqTradeAmount = bsqTradeAmount;
+            return this;
+        }
+
+        public AtomicTradeInfoBuilder withBsqMaxTradeAmount(long bsqMaxTradeAmount) {
+            this.bsqMaxTradeAmount = bsqMaxTradeAmount;
+            return this;
+        }
+
+        public AtomicTradeInfoBuilder withBsqMinTradeAmount(long bsqMinTradeAmount) {
+            this.bsqMinTradeAmount = bsqMinTradeAmount;
+            return this;
+        }
+
+        public AtomicTradeInfoBuilder withBtcTradeAmount(long btcTradeAmount) {
+            this.btcTradeAmount = btcTradeAmount;
+            return this;
+        }
+
+        public AtomicTradeInfoBuilder withBtcMaxTradeAmount(long btcMaxTradeAmount) {
+            this.btcMaxTradeAmount = btcMaxTradeAmount;
+            return this;
+        }
+
+        public AtomicTradeInfoBuilder withBtcMinTradeAmount(long btcMinTradeAmount) {
+            this.btcMinTradeAmount = btcMinTradeAmount;
+            return this;
+        }
+
+        public AtomicTradeInfoBuilder withTradePrice(long tradePrice) {
+            this.tradePrice = tradePrice;
+            return this;
+        }
+
+        public AtomicTradeInfoBuilder withIsCurrencyForMakerFeeBtc(boolean isCurrencyForMakerFeeBtc) {
+            this.isCurrencyForMakerFeeBtc = isCurrencyForMakerFeeBtc;
+            return this;
+        }
+
+        public AtomicTradeInfoBuilder withIsCurrencyForTakerFeeBtc(boolean isCurrencyForTakerFeeBtc) {
+            this.isCurrencyForTakerFeeBtc = isCurrencyForTakerFeeBtc;
+            return this;
+        }
+
+        public AtomicTradeInfoBuilder withBsqMakerTradeFee(long bsqMakerTradeFee) {
+            this.bsqMakerTradeFee = bsqMakerTradeFee;
+            return this;
+        }
+
+        public AtomicTradeInfoBuilder withBtcMakerTradeFee(long btcMakerTradeFee) {
+            this.btcMakerTradeFee = btcMakerTradeFee;
+            return this;
+        }
+
+        public AtomicTradeInfoBuilder withBsqTakerTradeFee(long bsqTakerTradeFee) {
+            this.bsqTakerTradeFee = bsqTakerTradeFee;
+            return this;
+        }
+
+        public AtomicTradeInfoBuilder withBtcTakerTradeFee(long btcTakerTradeFee) {
+            this.btcTakerTradeFee = btcTakerTradeFee;
+            return this;
+        }
+
+        public AtomicTradeInfoBuilder withTxFeePerVbyte(long txFeePerVbyte) {
+            this.txFeePerVbyte = txFeePerVbyte;
+            return this;
+        }
+
+        public AtomicTradeInfoBuilder withTxFee(long txFee) {
+            this.txFee = txFee;
+            return this;
+        }
+
+        public AtomicTradeInfoBuilder withMakerBsqAddress(String makerBsqAddress) {
+            this.makerBsqAddress = makerBsqAddress;
+            return this;
+        }
+
+        public AtomicTradeInfoBuilder withMakerBtcAddress(String makerBtcAddress) {
+            this.makerBtcAddress = makerBtcAddress;
+            return this;
+        }
+
+        public AtomicTradeInfoBuilder withTakerBsqAddress(String takerBsqAddress) {
+            this.takerBsqAddress = takerBsqAddress;
+            return this;
+        }
+
+        public AtomicTradeInfoBuilder withTakerBtcAddress(String takerBtcAddress) {
+            this.takerBtcAddress = takerBtcAddress;
+            return this;
+        }
+
+        public AtomicTradeInfoBuilder withTakeOfferDate(long takeOfferDate) {
+            this.takeOfferDate = takeOfferDate;
+            return this;
+        }
+
+        public AtomicTradeInfoBuilder withState(String state) {
+            this.state = state;
+            return this;
+        }
+
+        public AtomicTradeInfoBuilder withErrorMessage(String errorMessage) {
+            this.errorMessage = errorMessage;
+            return this;
+        }
+
+        public AtomicTradeInfo build() {
+            return new AtomicTradeInfo(this);
+        }
+    }
+}

--- a/core/src/main/java/bisq/core/offer/Offer.java
+++ b/core/src/main/java/bisq/core/offer/Offer.java
@@ -546,6 +546,10 @@ public class Offer implements NetworkPayload, PersistablePayload {
         return getOfferPayload().map(OfferPayload::isUseReOpenAfterAutoClose).orElse(false);
     }
 
+    public boolean isAtomicOffer() {
+        return getOfferPayloadI() instanceof AtomicOfferPayload;
+    }
+
     public boolean isXmrAutoConf() {
         if (!isXmr()) {
             return false;

--- a/core/src/main/java/bisq/core/offer/takeoffer/AtomicTakeOfferModel.java
+++ b/core/src/main/java/bisq/core/offer/takeoffer/AtomicTakeOfferModel.java
@@ -96,6 +96,7 @@ public class AtomicTakeOfferModel implements Model {
     private PaymentAccount paymentAccount;
     @Getter
     Price tradePrice;
+    @Getter
     private AtomicTxBuilder atomicTxBuilder;
 
 

--- a/core/src/main/java/bisq/core/trade/TradeManager.java
+++ b/core/src/main/java/bisq/core/trade/TradeManager.java
@@ -846,6 +846,10 @@ public class TradeManager implements PersistedDataHost, DecryptedDirectMessageLi
                 .findFirst();
     }
 
+    public Optional<AtomicTrade> getAtomicTradeById(String tradeId) {
+        return atomicTradeManager.getAtomicTradeById(tradeId);
+    }
+
     public Optional<Trade> getTradeById(String tradeId) {
         return getTradeModelById(tradeId)
                 .filter(tradeModel -> tradeModel instanceof Trade)

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcOffersService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcOffersService.java
@@ -18,14 +18,21 @@
 package bisq.daemon.grpc;
 
 import bisq.core.api.CoreApi;
+import bisq.core.api.model.AtomicOfferInfo;
 import bisq.core.api.model.OfferInfo;
 import bisq.core.offer.Offer;
 import bisq.core.offer.OpenOffer;
 
 import bisq.proto.grpc.CancelOfferReply;
 import bisq.proto.grpc.CancelOfferRequest;
+import bisq.proto.grpc.CreateAtomicOfferReply;
+import bisq.proto.grpc.CreateAtomicOfferRequest;
 import bisq.proto.grpc.CreateOfferReply;
 import bisq.proto.grpc.CreateOfferRequest;
+import bisq.proto.grpc.GetAtomicOfferReply;
+import bisq.proto.grpc.GetAtomicOffersReply;
+import bisq.proto.grpc.GetMyAtomicOfferReply;
+import bisq.proto.grpc.GetMyAtomicOffersReply;
 import bisq.proto.grpc.GetMyOfferReply;
 import bisq.proto.grpc.GetMyOfferRequest;
 import bisq.proto.grpc.GetMyOffersReply;
@@ -47,6 +54,7 @@ import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
 
+import static bisq.core.api.model.AtomicOfferInfo.toAtomicOfferInfo;
 import static bisq.core.api.model.OfferInfo.toOfferInfo;
 import static bisq.daemon.grpc.interceptor.GrpcServiceRateMeteringConfig.getCustomRateMeteringInterceptor;
 import static bisq.proto.grpc.OffersGrpc.*;
@@ -71,12 +79,43 @@ class GrpcOffersService extends OffersImplBase {
     }
 
     @Override
+    public void getAtomicOffer(GetOfferRequest req,
+                               StreamObserver<GetAtomicOfferReply> responseObserver) {
+        try {
+            Offer offer = coreApi.getOffer(req.getId());
+            var reply = GetAtomicOfferReply.newBuilder()
+                    .setAtomicOffer(toAtomicOfferInfo(offer).toProtoMessage())
+                    .build();
+            responseObserver.onNext(reply);
+            responseObserver.onCompleted();
+        } catch (Throwable cause) {
+            exceptionHandler.handleException(log, cause, responseObserver);
+        }
+    }
+
+    @Override
     public void getOffer(GetOfferRequest req,
                          StreamObserver<GetOfferReply> responseObserver) {
         try {
             Offer offer = coreApi.getOffer(req.getId());
             var reply = GetOfferReply.newBuilder()
                     .setOffer(toOfferInfo(offer).toProtoMessage())
+                    .build();
+            responseObserver.onNext(reply);
+            responseObserver.onCompleted();
+        } catch (Throwable cause) {
+            exceptionHandler.handleException(log, cause, responseObserver);
+        }
+    }
+
+    @Override
+    public void getMyAtomicOffer(GetMyOfferRequest req,
+                                 StreamObserver<GetMyAtomicOfferReply> responseObserver) {
+        try {
+            Offer offer = coreApi.getMyAtomicOffer(req.getId());
+            OpenOffer openOffer = coreApi.getMyOpenAtomicOffer(req.getId());
+            var reply = GetMyAtomicOfferReply.newBuilder()
+                    .setAtomicOffer(toAtomicOfferInfo(offer /* TODO support triggerPrice */).toProtoMessage())
                     .build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();
@@ -102,6 +141,25 @@ class GrpcOffersService extends OffersImplBase {
     }
 
     @Override
+    public void getAtomicOffers(GetOffersRequest req,
+                                StreamObserver<GetAtomicOffersReply> responseObserver) {
+        try {
+            List<AtomicOfferInfo> result = coreApi.getAtomicOffers(req.getDirection(), req.getCurrencyCode())
+                    .stream().map(AtomicOfferInfo::toAtomicOfferInfo)
+                    .collect(Collectors.toList());
+            var reply = GetAtomicOffersReply.newBuilder()
+                    .addAllAtomicOffers(result.stream()
+                            .map(AtomicOfferInfo::toProtoMessage)
+                            .collect(Collectors.toList()))
+                    .build();
+            responseObserver.onNext(reply);
+            responseObserver.onCompleted();
+        } catch (Throwable cause) {
+            exceptionHandler.handleException(log, cause, responseObserver);
+        }
+    }
+
+    @Override
     public void getOffers(GetOffersRequest req,
                           StreamObserver<GetOffersReply> responseObserver) {
         try {
@@ -111,6 +169,25 @@ class GrpcOffersService extends OffersImplBase {
             var reply = GetOffersReply.newBuilder()
                     .addAllOffers(result.stream()
                             .map(OfferInfo::toProtoMessage)
+                            .collect(Collectors.toList()))
+                    .build();
+            responseObserver.onNext(reply);
+            responseObserver.onCompleted();
+        } catch (Throwable cause) {
+            exceptionHandler.handleException(log, cause, responseObserver);
+        }
+    }
+
+    @Override
+    public void getMyAtomicOffers(GetMyOffersRequest req,
+                                  StreamObserver<GetMyAtomicOffersReply> responseObserver) {
+        try {
+            List<AtomicOfferInfo> result = coreApi.getMyAtomicOffers(req.getDirection(), req.getCurrencyCode())
+                    .stream().map(AtomicOfferInfo::toAtomicOfferInfo)
+                    .collect(Collectors.toList());
+            var reply = GetMyAtomicOffersReply.newBuilder()
+                    .addAllAtomicOffers(result.stream()
+                            .map(AtomicOfferInfo::toProtoMessage)
                             .collect(Collectors.toList()))
                     .build();
             responseObserver.onNext(reply);
@@ -140,10 +217,33 @@ class GrpcOffersService extends OffersImplBase {
     }
 
     @Override
+    public void createAtomicOffer(CreateAtomicOfferRequest req,
+                                  StreamObserver<CreateAtomicOfferReply> responseObserver) {
+        try {
+            coreApi.createAndPlaceAtomicOffer(
+                    req.getDirection(),
+                    req.getAmount(),
+                    req.getMinAmount(),
+                    req.getPrice(),
+                    req.getPaymentAccountId(),
+                    atomicOffer -> {
+                        AtomicOfferInfo atomicOfferInfo = toAtomicOfferInfo(atomicOffer);
+                        CreateAtomicOfferReply reply = CreateAtomicOfferReply.newBuilder()
+                                .setAtomicOffer(atomicOfferInfo.toProtoMessage())
+                                .build();
+                        responseObserver.onNext(reply);
+                        responseObserver.onCompleted();
+                    });
+        } catch (Throwable cause) {
+            exceptionHandler.handleException(log, cause, responseObserver);
+        }
+    }
+
+    @Override
     public void createOffer(CreateOfferRequest req,
                             StreamObserver<CreateOfferReply> responseObserver) {
         try {
-            coreApi.createAnPlaceOffer(
+            coreApi.createAndPlaceOffer(
                     req.getCurrencyCode(),
                     req.getDirection(),
                     req.getPrice(),
@@ -169,6 +269,7 @@ class GrpcOffersService extends OffersImplBase {
             exceptionHandler.handleException(log, cause, responseObserver);
         }
     }
+
 
     @Override
     public void cancelOffer(CancelOfferRequest req,

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcPaymentAccountsService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcPaymentAccountsService.java
@@ -136,7 +136,8 @@ class GrpcPaymentAccountsService extends PaymentAccountsImplBase {
             PaymentAccount paymentAccount = coreApi.createCryptoCurrencyPaymentAccount(req.getAccountName(),
                     req.getCurrencyCode(),
                     req.getAddress(),
-                    req.getTradeInstant());
+                    req.getTradeInstant(),
+                    req.getTradeAtomic());
             var reply = CreateCryptoCurrencyPaymentAccountReply.newBuilder()
                     .setPaymentAccount(paymentAccount.toProtoMessage())
                     .build();

--- a/daemon/src/main/java/bisq/daemon/grpc/GrpcTradesService.java
+++ b/daemon/src/main/java/bisq/daemon/grpc/GrpcTradesService.java
@@ -18,6 +18,7 @@
 package bisq.daemon.grpc;
 
 import bisq.core.api.CoreApi;
+import bisq.core.api.model.AtomicTradeInfo;
 import bisq.core.api.model.TradeInfo;
 import bisq.core.trade.Trade;
 
@@ -25,10 +26,13 @@ import bisq.proto.grpc.ConfirmPaymentReceivedReply;
 import bisq.proto.grpc.ConfirmPaymentReceivedRequest;
 import bisq.proto.grpc.ConfirmPaymentStartedReply;
 import bisq.proto.grpc.ConfirmPaymentStartedRequest;
+import bisq.proto.grpc.GetAtomicTradeReply;
 import bisq.proto.grpc.GetTradeReply;
 import bisq.proto.grpc.GetTradeRequest;
 import bisq.proto.grpc.KeepFundsReply;
 import bisq.proto.grpc.KeepFundsRequest;
+import bisq.proto.grpc.TakeAtomicOfferReply;
+import bisq.proto.grpc.TakeAtomicOfferRequest;
 import bisq.proto.grpc.TakeOfferReply;
 import bisq.proto.grpc.TakeOfferRequest;
 import bisq.proto.grpc.WithdrawFundsReply;
@@ -44,6 +48,7 @@ import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
 
+import static bisq.core.api.model.AtomicTradeInfo.toAtomicTradeInfo;
 import static bisq.core.api.model.TradeInfo.toTradeInfo;
 import static bisq.daemon.grpc.interceptor.GrpcServiceRateMeteringConfig.getCustomRateMeteringInterceptor;
 import static bisq.proto.grpc.TradesGrpc.*;
@@ -68,6 +73,51 @@ class GrpcTradesService extends TradesImplBase {
     }
 
     @Override
+    public void getAtomicTrade(GetTradeRequest req,
+                               StreamObserver<GetAtomicTradeReply> responseObserver) {
+        try {
+            var atomicTrade = coreApi.getAtomicTrade(req.getTradeId());
+            // String role = coreApi.getAtomicTradeRole(req.getTradeId());
+            var reply = GetAtomicTradeReply.newBuilder()
+                    .setAtomicTrade(toAtomicTradeInfo(atomicTrade).toProtoMessage())
+                    .build();
+            responseObserver.onNext(reply);
+            responseObserver.onCompleted();
+        } catch (IllegalArgumentException cause) {
+            // Offer makers may call 'gettrade' many times before a trade exists.
+            // Log a 'trade not found' warning instead of a full stack trace.
+            exceptionHandler.handleExceptionAsWarning(log, "getAtomicTrade", cause, responseObserver);
+        } catch (Throwable cause) {
+            exceptionHandler.handleException(log, cause, responseObserver);
+        }
+    }
+
+    @Override
+    public void takeAtomicOffer(TakeAtomicOfferRequest req,
+                                StreamObserver<TakeAtomicOfferReply> responseObserver) {
+        GrpcErrorMessageHandler errorMessageHandler =
+                new GrpcErrorMessageHandler(getTakeOfferMethod().getFullMethodName(),
+                        responseObserver,
+                        exceptionHandler,
+                        log);
+        coreApi.takeAtomicOffer(req.getOfferId(),
+                req.getPaymentAccountId(),
+                req.getTakerFeeCurrencyCode(),
+                atomicTrade -> {
+                    AtomicTradeInfo atomicTradeInfo = toAtomicTradeInfo(atomicTrade);
+                    var reply = TakeAtomicOfferReply.newBuilder()
+                            .setAtomicTrade(atomicTradeInfo.toProtoMessage())
+                            .build();
+                    responseObserver.onNext(reply);
+                    responseObserver.onCompleted();
+                },
+                errorMessage -> {
+                    if (!errorMessageHandler.isErrorHandled())
+                        errorMessageHandler.handleErrorMessage(errorMessage);
+                });
+    }
+
+    @Override
     public void getTrade(GetTradeRequest req,
                          StreamObserver<GetTradeReply> responseObserver) {
         try {
@@ -86,6 +136,7 @@ class GrpcTradesService extends TradesImplBase {
             exceptionHandler.handleException(log, cause, responseObserver);
         }
     }
+
 
     @Override
     public void takeOffer(TakeOfferRequest req,

--- a/proto/src/main/proto/grpc.proto
+++ b/proto/src/main/proto/grpc.proto
@@ -62,18 +62,32 @@ message GetMethodHelpReply {
 ///////////////////////////////////////////////////////////////////////////////////////////
 
 service Offers {
+    rpc GetAtomicOffer (GetOfferRequest) returns (GetAtomicOfferReply) {
+    }
     rpc GetOffer (GetOfferRequest) returns (GetOfferReply) {
+    }
+    rpc GetMyAtomicOffer (GetMyOfferRequest) returns (GetMyAtomicOfferReply) {
     }
     rpc GetMyOffer (GetMyOfferRequest) returns (GetMyOfferReply) {
     }
+    rpc GetAtomicOffers (GetOffersRequest) returns (GetAtomicOffersReply) {
+    }
     rpc GetOffers (GetOffersRequest) returns (GetOffersReply) {
     }
+    rpc GetMyAtomicOffers (GetMyOffersRequest) returns (GetMyAtomicOffersReply) {
+    }
     rpc GetMyOffers (GetMyOffersRequest) returns (GetMyOffersReply) {
+    }
+    rpc CreateAtomicOffer (CreateAtomicOfferRequest) returns (CreateAtomicOfferReply) {
     }
     rpc CreateOffer (CreateOfferRequest) returns (CreateOfferReply) {
     }
     rpc CancelOffer (CancelOfferRequest) returns (CancelOfferReply) {
     }
+}
+
+message GetAtomicOfferReply {
+    AtomicOfferInfo atomicOffer = 1;
 }
 
 message GetOfferRequest {
@@ -82,6 +96,10 @@ message GetOfferRequest {
 
 message GetOfferReply {
     OfferInfo offer = 1;
+}
+
+message GetMyAtomicOfferReply {
+    AtomicOfferInfo atomicOffer = 1;
 }
 
 message GetMyOfferRequest {
@@ -101,6 +119,10 @@ message GetOffersReply {
     repeated OfferInfo offers = 1;
 }
 
+message GetAtomicOffersReply {
+    repeated AtomicOfferInfo atomicOffers = 1;
+}
+
 message GetMyOffersRequest {
     string direction = 1;
     string currencyCode = 2;
@@ -108,6 +130,22 @@ message GetMyOffersRequest {
 
 message GetMyOffersReply {
     repeated OfferInfo offers = 1;
+}
+
+message GetMyAtomicOffersReply {
+    repeated AtomicOfferInfo atomicOffers = 1;
+}
+
+message CreateAtomicOfferRequest {
+    string direction = 1;
+    uint64 amount = 2;
+    uint64 minAmount = 3;
+    string price = 4;
+    string paymentAccountId = 5;
+}
+
+message CreateAtomicOfferReply {
+    AtomicOfferInfo atomicOffer = 1;
 }
 
 message CreateOfferRequest {
@@ -133,6 +171,26 @@ message CancelOfferRequest {
 }
 
 message CancelOfferReply {
+}
+
+message AtomicOfferInfo {
+    string id = 1;
+    string direction = 2;
+    uint64 amount = 3;
+    uint64 minAmount = 4;
+    uint64 price = 5;
+    string makerPaymentAccountId = 6;
+    string paymentMethodId = 7;
+    string paymentMethodShortName = 8;
+    string baseCurrencyCode = 9;
+    string counterCurrencyCode = 10;
+    uint64 getMakerFee = 11;
+    uint64 date = 12;
+    string ownerNodeAddress = 13;
+    string pubKeyRing = 14;
+    string versionNr = 15;
+    int32 protocolVersion = 16;
+    bool isCurrencyForMakerFeeBtc = 17;
 }
 
 message OfferInfo {
@@ -220,6 +278,7 @@ message CreateCryptoCurrencyPaymentAccountRequest {
     string currencyCode = 2;
     string address = 3;
     bool tradeInstant = 4;
+    bool tradeAtomic = 5;
 }
 
 message CreateCryptoCurrencyPaymentAccountReply {
@@ -286,7 +345,11 @@ message StopReply {
 ///////////////////////////////////////////////////////////////////////////////////////////
 
 service Trades {
+    rpc GetAtomicTrade (GetTradeRequest) returns (GetAtomicTradeReply) {
+    }
     rpc GetTrade (GetTradeRequest) returns (GetTradeReply) {
+    }
+    rpc TakeAtomicOffer (TakeAtomicOfferRequest) returns (TakeAtomicOfferReply) {
     }
     rpc TakeOffer (TakeOfferRequest) returns (TakeOfferReply) {
     }
@@ -298,6 +361,17 @@ service Trades {
     }
     rpc WithdrawFunds (WithdrawFundsRequest) returns (WithdrawFundsReply) {
     }
+}
+
+message TakeAtomicOfferRequest {
+    string offerId = 1;
+    string paymentAccountId = 2;
+    string takerFeeCurrencyCode = 3;
+}
+
+message TakeAtomicOfferReply {
+    AtomicTradeInfo atomicTrade = 1;
+    AvailabilityResultWithDescription failureReason = 2;
 }
 
 message TakeOfferRequest {
@@ -325,6 +399,10 @@ message ConfirmPaymentReceivedRequest {
 message ConfirmPaymentReceivedReply {
 }
 
+message GetAtomicTradeReply {
+    AtomicTradeInfo atomicTrade = 1;
+}
+
 message GetTradeRequest {
     string tradeId = 1;
 }
@@ -347,6 +425,36 @@ message WithdrawFundsRequest {
 }
 
 message WithdrawFundsReply {
+}
+
+message AtomicTradeInfo {
+    AtomicOfferInfo atomicOffer = 1;
+    string tradeId = 2;
+    string tempTradingPeerNodeAddress = 3;
+    string peerNodeAddress = 4;
+    string txId = 5;
+    uint64 bsqTradeAmount = 6;
+    uint64 bsqMaxTradeAmount = 7;
+    uint64 bsqMinTradeAmount = 8;
+    uint64 btcTradeAmount = 9;
+    uint64 btcMaxTradeAmount = 10;
+    uint64 btcMinTradeAmount = 11;
+    uint64 tradePrice = 12;
+    bool isCurrencyForMakerFeeBtc = 13;
+    bool isCurrencyForTakerFeeBtc = 14;
+    uint64 bsqMakerTradeFee = 15;
+    uint64 btcMakerTradeFee = 16;
+    uint64 bsqTakerTradeFee = 17;
+    uint64 btcTakerTradeFee = 18;
+    uint64 txFeePerVbyte = 19;
+    uint64 txFee = 20;
+    string makerBsqAddress = 21;
+    string makerBtcAddress = 22;
+    string takerBsqAddress = 23;
+    string takerBtcAddress = 24;
+    uint64 takeOfferDate = 25;
+    string state = 26;
+    string errorMessage = 27;
 }
 
 message TradeInfo {


### PR DESCRIPTION
`AtomicOfferTest` and `AtomicTradeTest` can be used to debug new api.

`AtomicTradeTestLoop` can be used to debug wallet inconsistency problems.

To run Bob & Alice daemons in debug mode, change the flag in `AbstractOfferTest`, line 61.
Alice remote debug port:  `49998`
Bob  remote debug port:  `49999`
